### PR TITLE
Base thumbnail dimensions on height

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Live demo at http://cdn.rawgit.com/nnarhinen/flowplayer-thumbnails/master/exampl
 ### Create thumbnails from video
 
 ```
-ffmpeg -i bauhaus.mp4 -vf scale=400:-1 -vf fps=1 bauhaus%d.jpg
+ffmpeg -i bauhaus.mp4 -filter:v scale=-1:160,fps=1 bauhaus%d.jpg
 ```
 
 ### Configuration
@@ -51,4 +51,4 @@ option     | required | default value | description
 :----------| ---------| :------------ | :----------
 `template` | yes      |               | The path from where to load the thumbnail images. Either a relative or absolute path. Use `{time}` as a placeholder for seconds.
 `preload`  | no       |`true`         | If `true`, then all images will be cached at player initialization to make them appear quicker.
-`width`    | no       | 200           | The thumbnail width
+`height`   | no       | 80            | The thumbnail height

--- a/flowplayer-thumbnails.js
+++ b/flowplayer-thumbnails.js
@@ -21,10 +21,10 @@
             percentage = delta / common.width(timeline),
             seconds = Math.round(percentage * api.video.duration);
         if (seconds < 1) return;
-        var width = c.width || 200;
+        var height = c.height || 80;
         common.css(timelineTooltip, {
-          width: width + 'px',
-          'padding-bottom': (api.conf.ratio * width) + 'px',
+          width: (height / api.conf.ratio) + 'px',
+          height: height + 'px',
           'background-image': "url('" + c.template.replace('{time}', seconds) + "')",
           'background-repeat': 'no-repeat',
           'background-size': 'cover',


### PR DESCRIPTION
As per
https://github.com/flowplayer/work/issues/887#issuecomment-151196868 ff.

Rationale:
This is a controlbar element. The controlbar is variable in width, but
fixed in height. Make thumbnails behave as the control element it
belongs to.

Update README, including modernization of ffmpeg example command.
