### PR TITLE
Do not load images when client does not support timeline tooltip (#3)

### DIFF
--- a/flowplayer-thumbnails.js
+++ b/flowplayer-thumbnails.js
@@ -5,8 +5,13 @@
   flowplayer(function(api, root) {
     var common = flowplayer.common,
         bean = flowplayer.bean,
+        support = flowplayer.support,
         timeline = common.find('.fp-timeline', root)[0],
         timelineTooltip = common.find('.fp-timeline-tooltip', root)[0];
+
+    if (support.touch || !support.inlineVideo) {
+      return;
+    }
 
     api.on('ready', function(ev, a, video) {
       cleanup();


### PR DESCRIPTION
- certainly not on devices which do not support inline playback
- also not on touch devices, see:
  https://github.com/flowplayer/flowplayer/issues/908#issuecomment-152988204
