### PR TITLE
More than 1 second between every thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ option     | required | default value | description
 `template` | yes      |               | The path from where to load the thumbnail images. Either a relative or absolute path. Use `{time}` as a placeholder for seconds.
 `preload`  | no       |`true`         | If `true`, then all images will be cached at player initialization to make them appear quicker.
 `height`   | no       | 80            | The thumbnail height.
+`interval` | no       | 1             | Seconds between thumbnails, set this if you want to have more than one second between images.
 
 ## CommonJS
 

--- a/flowplayer.thumbnails.js
+++ b/flowplayer.thumbnails.js
@@ -45,9 +45,15 @@
 
             var c = video.thumbnails || api.conf.thumbnails,
                 preloadImages = function (tmpl, max, start) {
+                    var add = 1;
                     if (start === undefined) {
                         start = 1;
                     }
+                    /* round up by interval ex: 4,8,12,16 */
+                    if(c.interval !== undefined && c.interval > 1) {
+                        start = start + (c.interval - (start % c.interval));
+                        add = c.interval; 
+                    }   
                     function load() {
                         if (start > max) {
                             return;
@@ -55,7 +61,7 @@
                         var img = new Image();
                         img.src = tmpl.replace('{time}', start);
                         img.onload = function () {
-                            start += 1;
+                            start += add;
                             load();
                         };
                     }
@@ -74,6 +80,10 @@
                     percentage = delta / common.width(timeline),
                     seconds = Math.round(percentage * api.video.duration);
 
+                /* round up by interval ex: 4,8,12,16, -1 for compatibility */
+                if(c.interval !== undefined && c.interval > 1) {
+                  seconds = seconds + (c.interval - (seconds % c.interval)) - 1;
+                }
                 // 2nd condition safeguards at out of range retrieval attempts
                 if (seconds < 0 || seconds > Math.round(api.video.duration)) {
                     return;

--- a/flowplayer.thumbnails.js
+++ b/flowplayer.thumbnails.js
@@ -45,15 +45,9 @@
 
             var c = video.thumbnails || api.conf.thumbnails,
                 preloadImages = function (tmpl, max, start) {
-                    var add = 1;
                     if (start === undefined) {
                         start = 1;
                     }
-                    /* round up by interval ex: 4,8,12,16 */
-                    if(c.interval !== undefined && c.interval > 1) {
-                        start = start + (c.interval - (start % c.interval));
-                        add = c.interval; 
-                    }   
                     function load() {
                         if (start > max) {
                             return;
@@ -61,7 +55,7 @@
                         var img = new Image();
                         img.src = tmpl.replace('{time}', start);
                         img.onload = function () {
-                            start += add;
+                            start += 1;
                             load();
                         };
                     }
@@ -80,13 +74,13 @@
                     percentage = delta / common.width(timeline),
                     seconds = Math.round(percentage * api.video.duration);
 
-                /* round up by interval ex: 4,8,12,16, -1 for compatibility */
-                if(c.interval !== undefined && c.interval > 1) {
-                  seconds = seconds + (c.interval - (seconds % c.interval)) - 1;
-                }
                 // 2nd condition safeguards at out of range retrieval attempts
                 if (seconds < 0 || seconds > Math.round(api.video.duration)) {
                     return;
+                }
+                /* enables greater interval than one second between thumbnails */
+                if(c.interval !== undefined && c.interval > 1 && seconds > 0) {
+                  seconds = Math.ceil(seconds / c.interval) -1;
                 }
                 var height = c.height || 80;
                 common.css(timelineTooltip, {


### PR DESCRIPTION
Hi

I have added the optional option "interval" to specify how many seconds you want between every thumbnail so you don't need to create one for every second. filename convention is the same as before.

example:
http://samuel.dalesjo.com/other/flowplayer-thumbnail-fork/
_use the slider below to adjust how many seconds you want between every thumbnail_

comments?
