### PR TITLE
Callback to format the time

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ flowplayer('#player', {
     title: 'Bauhaus',
     thumbnails: {
       template: 'thumbnails/bauhaus{time}.jpg'
+      time_format: function(t) {
+        return t + "-thumb.jpg";
+      }
     },
     sources: [{
       type: 'video/webm',

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ flowplayer('#player', {
     thumbnails: {
       template: 'thumbnails/bauhaus{time}.jpg',
       time_format: function(t) {
-        return t + "-thumb.jpg";
+        // An example using left padding.
+        var padding = "0000";
+        var formatted_time = padding.substring(0, padding.length - t.toString().length) + t;
+        return formatted_time + "-thumb.jpg";
       }
     },
     sources: [{

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ flowplayer('#player', {
   clip: {
     title: 'Bauhaus',
     thumbnails: {
-      template: 'thumbnails/bauhaus{time}.jpg'
+      template: 'thumbnails/bauhaus{time}.jpg',
       time_format: function(t) {
         return t + "-thumb.jpg";
       }

--- a/flowplayer.thumbnails.js
+++ b/flowplayer.thumbnails.js
@@ -12,7 +12,7 @@
 
    requires:
    - Flowplayer HTML5 version 6.x or greater
-   revision: $GIT_ID$
+   revision: 49f9cc5
 
 */
 (function (flowplayer) {
@@ -51,6 +51,7 @@
             var height = c.height || 80,
                 interval = c.interval || 1,
                 template = c.template,
+                time_format = c.time_format || function(t) { return t },
                 ratio = video.height / video.width,
                 preloadImages = function (tmpl, max, start) {
                     max = Math.floor(max / interval);
@@ -62,7 +63,7 @@
                             return;
                         }
                         var img = new Image();
-                        img.src = tmpl.replace('{time}', start);
+                        img.src = tmpl.replace('{time}', time_format(start));
                         img.onload = function () {
                             start += 1;
                             load();
@@ -92,7 +93,7 @@
                     width: (height / ratio) + 'px',
                     height: height + 'px',
                     // {time} template expected to start at 1, video time/first frame starts at 0
-                    'background-image': "url('" + template.replace('{time}', seconds + 1) + "')",
+                    'background-image': "url('" + template.replace('{time}', time_format(seconds + 1)) + "')",
                     'background-repeat': 'no-repeat',
                     'background-size': 'cover',
                     'background-position': 'center',

--- a/flowplayer.thumbnails.js
+++ b/flowplayer.thumbnails.js
@@ -12,7 +12,7 @@
 
    requires:
    - Flowplayer HTML5 version 6.x or greater
-   revision: 49f9cc5
+   revision: $GIT_ID$
 
 */
 (function (flowplayer) {


### PR DESCRIPTION
Adding a time_format callback to the configuration to allow the time to be formatted before being replaced in the template.
